### PR TITLE
DoubleTap2Wake for Samsung Galaxy Star GT-S5282 (SP8810)

### DIFF
--- a/drivers/input/touchscreen/Kconfig
+++ b/drivers/input/touchscreen/Kconfig
@@ -871,4 +871,15 @@ config TOUCHSCREEN_IST30XX
           To compile this driver as a module, choose M here: the
           module will be called ist30xx.   
                     
+config TOUCHSCREEN_DOUBLETAP2WAKE
+    tristate "DoubleTap2Wake for touchscreens"
+    select TOUCHSCREEN_PREVENT_SLEEP
+    default n
+
+config TOUCHSCREEN_PREVENT_SLEEP
+    bool "Inihibit sleep on modified touchscreen drivers"
+    default n
+    help
+      This disables the sleep function of modified touchscreen drivers.
+
 endif

--- a/drivers/input/touchscreen/Makefile
+++ b/drivers/input/touchscreen/Makefile
@@ -72,3 +72,4 @@ obj-$(CONFIG_TOUCHSCREEN_TMA140)	+= cypress_tma140_cori2g.o
 obj-$(CONFIG_TOUCHSCREEN_MMS134S_TS) += mms134s_ts.o MMS100S_ISC_Updater_Customize.o MMS100S_ISC_Updater_V01.o
 obj-$(CONFIG_TOUCHSCREEN_SILABS_F760) += silabs_f760.o bl_master.o
 obj-$(CONFIG_TOUCHSCREEN_IST30XX) += ist30xx.o ist30xx_misc.o ist30xx_sys.o ist30xx_update.o ist30xx_sec_test.o
+obj-$(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE) += doubletap2wake.o

--- a/drivers/input/touchscreen/doubletap2wake.c
+++ b/drivers/input/touchscreen/doubletap2wake.c
@@ -1,0 +1,459 @@
+/*
+ * drivers/input/touchscreen/doubletap2wake.c
+ *
+ *
+ * Copyright (c) 2013, Dennis Rassmann <showp1984@gmail.com>
+ * Copyright (c) 2015, Vineeth Raj <contact.twn@openmailbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/types.h>
+#include <linux/delay.h>
+#include <linux/init.h>
+#include <linux/err.h>
+#include <linux/input/doubletap2wake.h>
+#include <linux/slab.h>
+#include <linux/workqueue.h>
+#include <linux/input.h>
+#include <linux/hrtimer.h>
+#include <asm-generic/cputime.h>
+
+/* uncomment since no touchscreen defines android touch, do that here */
+//#define ANDROID_TOUCH_DECLARED
+
+/* uncomment if dt2w_scr_suspended is updated automagically */
+#define WAKE_HOOKS_DEFINED
+
+#ifndef WAKE_HOOKS_DEFINED
+#ifndef CONFIG_HAS_EARLYSUSPEND
+#include <linux/lcd_notify.h>
+#else
+#include <linux/earlysuspend.h>
+#endif
+#endif // WAKE_HOOKS_DEFINED
+
+/* Version, author, desc, etc */
+#define DRIVER_AUTHOR "Dennis Rassmann <showp1984@gmail.com>"
+#define DRIVER_DESCRIPTION "Doubletap2wake for almost any device"
+#define DRIVER_VERSION "1.0"
+#define LOGTAG "[doubletap2wake]: "
+
+MODULE_AUTHOR(DRIVER_AUTHOR);
+MODULE_DESCRIPTION(DRIVER_DESCRIPTION);
+MODULE_VERSION(DRIVER_VERSION);
+MODULE_LICENSE("GPLv2");
+
+/* Tuneables */
+#define DT2W_DEBUG		0
+#define DT2W_DEFAULT		0
+
+#define DT2W_PWRKEY_DUR		60
+#define DT2W_FEATHER		200
+#define DT2W_TIME		700
+
+/* Resources */
+int dt2w_switch = DT2W_DEFAULT;
+static cputime64_t tap_time_pre = 0;
+static int touch_x = 0, touch_y = 0, touch_nr = 0, x_pre = 0, y_pre = 0;
+static bool touch_x_called = false, touch_y_called = false, touch_cnt = true;
+static bool exec_count = true;
+bool dt2w_scr_suspended = false;
+#ifndef WAKE_HOOKS_DEFINED
+#ifndef CONFIG_HAS_EARLYSUSPEND
+static struct notifier_block dt2w_lcd_notif;
+#endif
+#endif // WAKE_HOOKS_DEFINED
+static struct input_dev * doubletap2wake_pwrdev;
+static DEFINE_MUTEX(pwrkeyworklock);
+static struct workqueue_struct *dt2w_input_wq;
+static struct work_struct dt2w_input_work;
+
+/* Read cmdline for dt2w */
+static int __init read_dt2w_cmdline(char *dt2w)
+{
+	if (strcmp(dt2w, "1") == 0) {
+		pr_info("[cmdline_dt2w]: DoubleTap2Wake enabled. | dt2w='%s'\n", dt2w);
+		dt2w_switch = 1;
+	} else if (strcmp(dt2w, "0") == 0) {
+		pr_info("[cmdline_dt2w]: DoubleTap2Wake disabled. | dt2w='%s'\n", dt2w);
+		dt2w_switch = 0;
+	} else {
+		pr_info("[cmdline_dt2w]: No valid input found. Going with default: | dt2w='%u'\n", dt2w_switch);
+	}
+	return 1;
+}
+__setup("dt2w=", read_dt2w_cmdline);
+
+/* reset on finger release */
+static void doubletap2wake_reset(void) {
+	exec_count = true;
+	touch_nr = 0;
+	tap_time_pre = 0;
+	x_pre = 0;
+	y_pre = 0;
+}
+
+/* PowerKey work func */
+static void doubletap2wake_presspwr(struct work_struct * doubletap2wake_presspwr_work) {
+	if (!mutex_trylock(&pwrkeyworklock))
+                return;
+	input_event(doubletap2wake_pwrdev, EV_KEY, KEY_POWER, 1);
+	input_event(doubletap2wake_pwrdev, EV_SYN, 0, 0);
+	msleep(DT2W_PWRKEY_DUR);
+	input_event(doubletap2wake_pwrdev, EV_KEY, KEY_POWER, 0);
+	input_event(doubletap2wake_pwrdev, EV_SYN, 0, 0);
+	msleep(DT2W_PWRKEY_DUR);
+        mutex_unlock(&pwrkeyworklock);
+	return;
+}
+static DECLARE_WORK(doubletap2wake_presspwr_work, doubletap2wake_presspwr);
+
+/* PowerKey trigger */
+static void doubletap2wake_pwrtrigger(void) {
+	schedule_work(&doubletap2wake_presspwr_work);
+        return;
+}
+
+/* unsigned */
+static unsigned int calc_feather(int coord, int prev_coord) {
+	int calc_coord = 0;
+	calc_coord = coord-prev_coord;
+	if (calc_coord < 0)
+		calc_coord = calc_coord * (-1);
+	return calc_coord;
+}
+
+/* init a new touch */
+static void new_touch(int x, int y) {
+	tap_time_pre = ktime_to_ms(ktime_get());
+	x_pre = x;
+	y_pre = y;
+	touch_nr++;
+}
+
+/* Doubletap2wake main function */
+static void detect_doubletap2wake(int x, int y, bool st)
+{
+        bool single_touch = st;
+#if DT2W_DEBUG
+        pr_info(LOGTAG"x,y(%4d,%4d) single:%s\n",
+                x, y, (single_touch) ? "true" : "false");
+#endif
+	if ((single_touch) && (dt2w_switch > 0) && (exec_count) && (touch_cnt)) {
+		touch_cnt = false;
+		if (touch_nr == 0) {
+			new_touch(x, y);
+		} else if (touch_nr == 1) {
+			if ((calc_feather(x, x_pre) < DT2W_FEATHER) &&
+			    (calc_feather(y, y_pre) < DT2W_FEATHER) &&
+			    ((ktime_to_ms(ktime_get())-tap_time_pre) < DT2W_TIME))
+				touch_nr++;
+			else {
+				doubletap2wake_reset();
+				new_touch(x, y);
+			}
+		} else {
+			doubletap2wake_reset();
+			new_touch(x, y);
+		}
+		if ((touch_nr > 1)) {
+			pr_info(LOGTAG"ON\n");
+			exec_count = false;
+			doubletap2wake_pwrtrigger();
+			doubletap2wake_reset();
+		}
+	}
+}
+
+static void dt2w_input_callback(struct work_struct *unused) {
+	detect_doubletap2wake(touch_x, touch_y, true);
+
+	return;
+}
+
+static void dt2w_input_event(struct input_handle *handle, unsigned int type,
+				unsigned int code, int value) {
+#if DT2W_DEBUG
+	pr_info("doubletap2wake: code: %s|%u, val: %i\n",
+		((code==ABS_MT_POSITION_X) ? "X" :
+		(code==ABS_MT_POSITION_Y) ? "Y" :
+		(code==ABS_MT_TRACKING_ID) ? "ID" :
+		"undef"), code, value);
+#endif
+	if (!dt2w_scr_suspended)
+		return;
+
+	if (code == ABS_MT_SLOT) {
+		doubletap2wake_reset();
+		return;
+	}
+
+	if (code == ABS_MT_TRACKING_ID && value == -1) {
+		touch_cnt = true;
+		return;
+	}
+
+	if (code == ABS_MT_POSITION_X) {
+		touch_x = value;
+		touch_x_called = true;
+	}
+
+	if (code == ABS_MT_POSITION_Y) {
+		touch_y = value;
+		touch_y_called = true;
+	}
+
+	if (touch_x_called || touch_y_called) {
+		touch_x_called = false;
+		touch_y_called = false;
+		queue_work_on(0, dt2w_input_wq, &dt2w_input_work);
+	}
+}
+
+static int input_dev_filter(struct input_dev *dev) {
+	if (strstr(dev->name, "sec_touch")
+			||strstr(dev->name, "ist30xx_ts")) {
+		return 0;
+	} else {
+		return 1;
+	}
+}
+
+static int dt2w_input_connect(struct input_handler *handler,
+				struct input_dev *dev, const struct input_device_id *id) {
+	struct input_handle *handle;
+	int error;
+
+	if (input_dev_filter(dev))
+		return -ENODEV;
+
+	handle = kzalloc(sizeof(struct input_handle), GFP_KERNEL);
+	if (!handle)
+		return -ENOMEM;
+
+	handle->dev = dev;
+	handle->handler = handler;
+	handle->name = "dt2w";
+
+	error = input_register_handle(handle);
+	if (error)
+		goto err2;
+
+	error = input_open_device(handle);
+	if (error)
+		goto err1;
+
+	return 0;
+err1:
+	input_unregister_handle(handle);
+err2:
+	kfree(handle);
+	return error;
+}
+
+static void dt2w_input_disconnect(struct input_handle *handle) {
+	input_close_device(handle);
+	input_unregister_handle(handle);
+	kfree(handle);
+}
+
+static const struct input_device_id dt2w_ids[] = {
+	{ .driver_info = 1 },
+	{ },
+};
+
+static struct input_handler dt2w_input_handler = {
+	.event		= dt2w_input_event,
+	.connect	= dt2w_input_connect,
+	.disconnect	= dt2w_input_disconnect,
+	.name		= "dt2w_inputreq",
+	.id_table	= dt2w_ids,
+};
+
+#ifndef WAKE_HOOKS_DEFINED
+#ifndef CONFIG_HAS_EARLYSUSPEND
+static int lcd_notifier_callback(struct notifier_block *this,
+				unsigned long event, void *data)
+{
+	switch (event) {
+	case LCD_EVENT_ON_END:
+		dt2w_scr_suspended = false;
+		break;
+	case LCD_EVENT_OFF_END:
+		dt2w_scr_suspended = true;
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+#else
+static void dt2w_early_suspend(struct early_suspend *h) {
+	dt2w_scr_suspended = true;
+}
+
+static void dt2w_late_resume(struct early_suspend *h) {
+	dt2w_scr_suspended = false;
+}
+
+static struct early_suspend dt2w_early_suspend_handler = {
+	.level = EARLY_SUSPEND_LEVEL_BLANK_SCREEN,
+	.suspend = dt2w_early_suspend,
+	.resume = dt2w_late_resume,
+};
+#endif
+#endif // WAKE_HOOKS_DEFINED
+
+/*
+ * SYSFS stuff below here
+ */
+static ssize_t dt2w_doubletap2wake_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	size_t count = 0;
+
+	count += sprintf(buf, "%d\n", dt2w_switch);
+
+	return count;
+}
+
+static ssize_t dt2w_doubletap2wake_dump(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	if (buf[0] >= '0' && buf[0] <= '2' && buf[1] == '\n')
+                if (dt2w_switch != buf[0] - '0')
+		        dt2w_switch = buf[0] - '0';
+
+	return count;
+}
+
+static DEVICE_ATTR(doubletap2wake, (S_IWUSR|S_IRUGO),
+	dt2w_doubletap2wake_show, dt2w_doubletap2wake_dump);
+
+static ssize_t dt2w_version_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	size_t count = 0;
+
+	count += sprintf(buf, "%s\n", DRIVER_VERSION);
+
+	return count;
+}
+
+static ssize_t dt2w_version_dump(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	return count;
+}
+
+static DEVICE_ATTR(doubletap2wake_version, (S_IWUSR|S_IRUGO),
+	dt2w_version_show, dt2w_version_dump);
+
+/*
+ * INIT / EXIT stuff below here
+ */
+#ifdef ANDROID_TOUCH_DECLARED
+extern struct kobject *android_touch_kobj;
+#else
+struct kobject *android_touch_kobj;
+EXPORT_SYMBOL_GPL(android_touch_kobj);
+#endif
+static int __init doubletap2wake_init(void)
+{
+	int rc = 0;
+
+	doubletap2wake_pwrdev = input_allocate_device();
+	if (!doubletap2wake_pwrdev) {
+		pr_err("Can't allocate suspend autotest power button\n");
+		goto err_alloc_dev;
+	}
+
+	input_set_capability(doubletap2wake_pwrdev, EV_KEY, KEY_POWER);
+	doubletap2wake_pwrdev->name = "dt2w_pwrkey";
+	doubletap2wake_pwrdev->phys = "dt2w_pwrkey/input0";
+
+	rc = input_register_device(doubletap2wake_pwrdev);
+	if (rc) {
+		pr_err("%s: input_register_device err=%d\n", __func__, rc);
+		goto err_input_dev;
+	}
+
+	dt2w_input_wq = create_workqueue("dt2wiwq");
+	if (!dt2w_input_wq) {
+		pr_err("%s: Failed to create dt2wiwq workqueue\n", __func__);
+		return -EFAULT;
+	}
+	INIT_WORK(&dt2w_input_work, dt2w_input_callback);
+	rc = input_register_handler(&dt2w_input_handler);
+	if (rc)
+		pr_err("%s: Failed to register dt2w_input_handler\n", __func__);
+
+#ifndef WAKE_HOOKS_DEFINED
+#ifndef CONFIG_HAS_EARLYSUSPEND
+	dt2w_lcd_notif.notifier_call = lcd_notifier_callback;
+	if (lcd_register_client(&dt2w_lcd_notif) != 0) {
+		pr_err("%s: Failed to register lcd callback\n", __func__);
+	}
+#else
+	register_early_suspend(&dt2w_early_suspend_handler);
+#endif
+#endif // WAKE_HOOKS_DEFINED
+
+#ifndef ANDROID_TOUCH_DECLARED
+	android_touch_kobj = kobject_create_and_add("android_touch", NULL) ;
+	if (android_touch_kobj == NULL) {
+		pr_warn("%s: android_touch_kobj create_and_add failed\n", __func__);
+	}
+#endif
+	rc = sysfs_create_file(android_touch_kobj, &dev_attr_doubletap2wake.attr);
+	if (rc) {
+		pr_warn("%s: sysfs_create_file failed for doubletap2wake\n", __func__);
+	}
+	rc = sysfs_create_file(android_touch_kobj, &dev_attr_doubletap2wake_version.attr);
+	if (rc) {
+		pr_warn("%s: sysfs_create_file failed for doubletap2wake_version\n", __func__);
+	}
+
+err_input_dev:
+	input_free_device(doubletap2wake_pwrdev);
+err_alloc_dev:
+	pr_info(LOGTAG"%s done\n", __func__);
+
+	return 0;
+}
+
+static void __exit doubletap2wake_exit(void)
+{
+#ifndef ANDROID_TOUCH_DECLARED
+	kobject_del(android_touch_kobj);
+#endif
+#ifndef WAKE_HOOKS_DEFINED
+#ifndef CONFIG_HAS_EARLYSUSPEND
+	lcd_unregister_client(&dt2w_lcd_notif);
+#endif
+#endif
+	input_unregister_handler(&dt2w_input_handler);
+	destroy_workqueue(dt2w_input_wq);
+	input_unregister_device(doubletap2wake_pwrdev);
+	input_free_device(doubletap2wake_pwrdev);
+	return;
+}
+
+module_init(doubletap2wake_init);
+module_exit(doubletap2wake_exit);

--- a/drivers/input/touchscreen/ist30xx.c
+++ b/drivers/input/touchscreen/ist30xx.c
@@ -39,6 +39,12 @@
 
 #include <linux/input/mt.h>
 
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#ifdef CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE
+#include <linux/input/doubletap2wake.h>
+#endif
+#endif
+
 #if IST30XX_DEBUG
 #include "ist30xx_misc.h"
 #endif
@@ -868,19 +874,61 @@ static ssize_t firmware_update_status(struct device *dev, struct device_attribut
 
 void ist30xx_disable_irq(struct ist30xx_data *data)
 {
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#if defined(CONFIG_TOUCHSCREEN_SWEEP2WAKE) || defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	bool prevent_sleep = false;
+#endif
+#if defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	prevent_sleep = prevent_sleep || (dt2w_switch > 0);
+#endif
+#endif
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+	if (prevent_sleep) {
+		enable_irq_wake(data->client->irq);
+	} else {
+#endif
+
 	if (data->irq_enabled) {
 		disable_irq(data->client->irq);
 		data->irq_enabled = 0;
 	}
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+	} //prevent_sleep
+#endif
+
 }
 
 void ist30xx_enable_irq(struct ist30xx_data *data)
 {
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#if defined(CONFIG_TOUCHSCREEN_SWEEP2WAKE) || defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	bool prevent_sleep = false;
+#endif
+#if defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	prevent_sleep = prevent_sleep || (dt2w_switch > 0);
+#endif
+#endif
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+	if (prevent_sleep) {
+		disable_irq_wake(data->client->irq);
+	} else {
+#endif
+
 	if (!data->irq_enabled) {
 		enable_irq(data->client->irq);
 		msleep(50);
 		data->irq_enabled = 1;
 	}
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+	} //prevent_sleep
+#endif
+
 }
 
 int ist30xx_max_error_cnt = MAX_ERR_CNT;
@@ -1667,7 +1715,11 @@ static int __devinit ist30xx_probe(struct i2c_client *		client,
 #endif
 
 	ret = request_threaded_irq(client->irq, NULL, ist30xx_irq_thread,
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+				   IRQF_TRIGGER_FALLING | IRQF_ONESHOT | IRQF_NO_SUSPEND, "ist30xx_ts", data);
+#else
 				   IRQF_TRIGGER_FALLING | IRQF_ONESHOT, "ist30xx_ts", data);
+#endif
 	if (ret)
 		goto err_irq;
 

--- a/drivers/input/touchscreen/ist30xx_sys.c
+++ b/drivers/input/touchscreen/ist30xx_sys.c
@@ -22,6 +22,12 @@
 #include <mach/gpio.h>
 #include "ist30xx.h"
 
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#ifdef CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE
+#include <linux/input/doubletap2wake.h>
+#endif
+#endif
+
 /******************************************************************************
  * Return value of Error
  * EPERM  : 1
@@ -230,12 +236,33 @@ int ist30xx_power_on(void)
 
 int ist30xx_power_off(void)
 {
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#if defined(CONFIG_TOUCHSCREEN_SWEEP2WAKE) || defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	bool prevent_sleep = false;
+#endif
+#if defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	prevent_sleep = prevent_sleep || (dt2w_switch > 0);
+#endif
+#endif
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+	if (prevent_sleep) {
+		; // do nothing
+	} else { // power off screen.
+#endif
+
 	if (ts_data->status.power != 0) {
         	ts_power_enable(0);
 		// TODO : place power off code here.
 		ts_data->status.power = 0;
 		DMSG("[ TSP ] IST30XX Power off!\n");
        }
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+	} //prevent_sleep
+#endif
+
 	return 0;
 }
 

--- a/drivers/video/spreadtrum/lcdc.c
+++ b/drivers/video/spreadtrum/lcdc.c
@@ -24,6 +24,12 @@
 
 #include "sprdfb.h"
 
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#if defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+#include <linux/input/doubletap2wake.h>
+#endif
+#endif
+
 extern void lcdc_dithering_enable(void);
 
 struct sprd_lcd_controller {
@@ -422,6 +428,13 @@ static int32_t sprd_lcdc_suspend(struct sprdfb_device *dev)
 		clk_disable(lcdc.clk_lcdc);
 	}
 	up(&dev->work_proceedure_lock);	
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#if defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	dt2w_scr_suspended = true;
+#endif
+#endif
+
 	return 0;
 }
 
@@ -487,6 +500,13 @@ static int32_t sprd_lcdc_resume(struct sprdfb_device *dev)
 		dev->enable = 1;
 	}
 	up(&dev->work_proceedure_lock);	
+
+#ifdef CONFIG_TOUCHSCREEN_PREVENT_SLEEP
+#if defined(CONFIG_TOUCHSCREEN_DOUBLETAP2WAKE)
+	dt2w_scr_suspended = false;
+#endif
+#endif
+
 	return 0;
 }
 

--- a/include/linux/input/doubletap2wake.h
+++ b/include/linux/input/doubletap2wake.h
@@ -1,0 +1,28 @@
+/*
+ * include/linux/input/doubletap2wake.h
+ *
+ * Copyright (c) 2013, Dennis Rassmann <showp1984@gmail.com>
+ * Copyright (c) 2015, Vineeth Raj <contact.twn@openmailbox.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef _LINUX_DOUBLETAP2WAKE_H
+#define _LINUX_DOUBLETAP2WAKE_H
+
+extern bool dt2w_scr_suspended;
+extern int dt2w_switch;
+
+#endif	/* _LINUX_DOUBLETAP2WAKE_H */


### PR DESCRIPTION
* thanks to @showp1984 for doubletap2wake module
* uncomment android_touch_declared; we don't have it
* wake hooks (for updating dt2w_scr_suspended) directly
  hook to fb_suspend and fb_resume
* ist30xx: add prevent_sleep functionality
* enable with the following lines in defconfig:
  +CONFIG_TOUCHSCREEN_SWEEP2WAKE=y
  +CONFIG_TOUCHSCREEN_PREVENT_SLEEP=y

Signed-off-by: Vineeth Raj <contact.twn@openmailbox.org>